### PR TITLE
Default enable the app

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -12,4 +12,5 @@
 	<dependencies>
 		<owncloud min-version="9.0" max-version="9.1" />
 	</dependencies>
+	<default_enable/>
 </info>


### PR DESCRIPTION
In my opinion we should default enable generally useful features like this one, it also makes it easier for admins to see what features we do offer. 

The following policies will be enforced by default (but can of course be adjusted in the admin panel):

- Password has at least 10 characters
- Password is not one of the 1,000,000 most used ones

@schiessle @karlitschek Objections?