### PR TITLE
Allow to check against haveibeenpwned.com password list

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -2,17 +2,20 @@
 <info>
 	<id>password_policy</id>
 	<name>Password policy</name>
-	<namespace>Password_Policy</namespace>
+	<summary>Allows admins to configure a password policy</summary>
 	<description>
 		Allow admin to define certain pre-conditions for password, e.g. enforce a minimum length
 	</description>
-	<licence>AGPL</licence>
-	<author>Bjoern Schiessle</author>
 	<version>1.4.0</version>
+	<licence>agpl</licence>
+	<author>Bjoern Schiessle</author>
+	<namespace>Password_Policy</namespace>
+	<default_enable/>
+	<category>security</category>
+	<bugs>https://github.com/nextcloud/password_policy/issues</bugs>
 	<dependencies>
 		<nextcloud min-version="14" max-version="14" />
 	</dependencies>
-	<default_enable/>
 
 	<settings>
 		<admin>OCA\Password_Policy\Settings</admin>

--- a/css/settings-admin.css
+++ b/css/settings-admin.css
@@ -1,3 +1,8 @@
 #password-policy-min-length {
 	width: 75px;
 }
+
+.password-policy-settings-hint {
+	opacity: 0.7;
+	padding-left: 19px;
+}

--- a/js/settings-admin.js
+++ b/js/settings-admin.js
@@ -76,6 +76,13 @@ $(document).ready(function(){
 		}
 		OCP.AppConfig.setValue('password_policy', 'enforceSpecialCharacters', value);
 	});
+	$('#password-policy-enforce-have-i-been-pwned').click(function() {
+		var value = '0';
+		if (this.checked) {
+			value = '1';
+		}
+		OCP.AppConfig.setValue('password_policy', 'enforceHaveIBeenPwned', value);
+	});
 
 	$('#password-policy-min-length').keyup(function (e) {
 		if (e.keyCode === 13) {

--- a/lib/PasswordPolicyConfig.php
+++ b/lib/PasswordPolicyConfig.php
@@ -154,4 +154,26 @@ class PasswordPolicyConfig {
 		$this->config->setAppValue('password_policy', 'enforceSpecialCharacters', $value);
 	}
 
+	/**
+	 * Do we check against the HaveIBeenPwned passwords
+	 *
+	 * @return bool
+	 */
+	public function getEnforceHaveIBeenPwned() {
+		return $this->config->getAppValue(
+			'password_policy',
+			'enforceHaveIBeenPwned',
+			'0'
+		) === '1';
+	}
+
+	/**
+	 * Enforce checking against haveibeenpwned.com
+	 *
+	 * @param bool $enforceHaveIBeenPwned
+	 */
+	public function setEnforceHaveIBeenPwned($enforceHaveIBeenPwned) {
+		$this->config->setAppValue('password_policy', 'enforceHaveIBeenPwned', $enforceHaveIBeenPwned ? '1' : '0');
+	}
+
 }

--- a/lib/PasswordValidator.php
+++ b/lib/PasswordValidator.php
@@ -24,6 +24,7 @@ namespace OCA\Password_Policy;
 
 
 use OC\HintException;
+use OCP\Http\Client\IClientService;
 use OCP\IL10N;
 
 class PasswordValidator {
@@ -34,15 +35,22 @@ class PasswordValidator {
 	/** @var IL10N */
 	private $l;
 
+	/** @var IClientService */
+	private $clientService;
+
 	/**
 	 * PasswordValidator constructor.
 	 *
 	 * @param PasswordPolicyConfig $config
 	 * @param IL10N $l
+	 * @param IClientService $clientService
 	 */
-	public function __construct(PasswordPolicyConfig $config, IL10N $l) {
+	public function __construct(PasswordPolicyConfig $config,
+								IL10N $l,
+								IClientService $clientService) {
 		$this->config = $config;
 		$this->l = $l;
+		$this->clientService = $clientService;
 	}
 
 	/**
@@ -57,6 +65,7 @@ class PasswordValidator {
 		$this->checkNumericCharacters($password);
 		$this->checkUpperLowerCase($password);
 		$this->checkSpecialCharacters($password);
+		$this->checkHaveIBeenPwned($password);
 	}
 
 	/**
@@ -151,6 +160,44 @@ class PasswordValidator {
 					);
 					throw new HintException($message, $message_t);
 				}
+			}
+		}
+	}
+
+	/**
+	 * Check if a password is in the list of breached passwords from
+	 * haveibeenpwned.com
+	 *
+	 * @param string $password
+	 * @throws HintException
+	 */
+	protected function checkHaveIBeenPwned($password) {
+		if ($this->config->getEnforceHaveIBeenPwned()) {
+			$hash = sha1($password);
+			$range = substr($hash, 0, 5);
+			$needle = strtoupper(substr($hash, 5));
+
+			$client = $this->clientService->newClient();
+
+			try {
+				$response = $client->get(
+					'https://api.pwnedpasswords.com/range/' . $range,
+					[
+						'timeout' => 5
+					]
+				);
+			} catch (\Exception $e) {
+				return;
+			}
+
+			$result = $response->getBody();
+
+			if (strpos($result, $needle) !== false) {
+				$message = 'Password is present in compromised password list. Please choose a different password.';
+				$message_t = $this->l->t(
+					'Password is present in compromised password list. Please choose a different password.'
+				);
+				throw new HintException($message, $message_t);
 			}
 		}
 	}

--- a/lib/Settings.php
+++ b/lib/Settings.php
@@ -43,6 +43,7 @@ class Settings implements ISettings {
 			'enforceUpperLowerCase' => $this->config->getEnforceUpperLowerCase(),
 			'enforceNumericCharacters' => $this->config->getEnforceNumericCharacters(),
 			'enforceSpecialCharacters' => $this->config->getEnforceSpecialCharacters(),
+			'enforceHaveIBeenPwned' => $this->config->getEnforceHaveIBeenPwned(),
 		]);
 
 		return $response;

--- a/templates/settings-admin.php
+++ b/templates/settings-admin.php
@@ -55,4 +55,12 @@ style('password_policy', 'settings-admin');
 			   value="1" <?php if ($_['enforceSpecialCharacters']) print_unescaped('checked="checked"'); ?> />
 		<label for="password-policy-enforce-special-characters"><?php p($l->t('Enforce special characters'));?></label><br/>
 	</p>
+	<p id="enforceHaveIBeenPwned">
+		<input type="checkbox" name="password-policy-enforce-have-i-been-pwned" id="password-policy-enforce-have-i-been-pwned" class="checkbox"
+			   value="1" <?php if ($_['enforceHaveIBeenPwned']) print_unescaped('checked="checked"'); ?> />
+		<label for="password-policy-enforce-have-i-been-pwned"><?php p($l->t('Check password against the list of breached passwords from haveibeenpwnd.com'));?></label><br/>
+	</p>
+	<p class="password-policy-settings-hint">
+		This check creates a hash of the password and sends the first 5 characters of this hash to the haveibeenpwnd.com API to retrieve a list of all hashes that start with those. Then it checks on the Nextcloud instance if the password hash is in the result set.
+	</p>
 </div>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -6,7 +6,7 @@ if (!defined('PHPUNIT_RUN')) {
 
 require_once __DIR__ . '/../../../lib/base.php';
 
-if(!class_exists('PHPUnit_Framework_TestCase')) {
+if(!class_exists('\PHPUnit\Framework\TestCase')) {
 	require_once('PHPUnit/Autoload.php');
 }
 \OC_App::loadApp('password_policy');

--- a/tests/lib/controller/PasswordValidatorTest.php
+++ b/tests/lib/controller/PasswordValidatorTest.php
@@ -26,6 +26,7 @@ namespace OCA\Password_Policy\Tests;
 use OC\HintException;
 use OCA\Password_Policy\PasswordPolicyConfig;
 use OCA\Password_Policy\PasswordValidator;
+use OCP\Http\Client\IClientService;
 use OCP\IL10N;
 use Test\TestCase;
 
@@ -37,11 +38,15 @@ class PasswordValidatorTest extends TestCase {
 	/** @var  IL10N|\PHPUnit_Framework_MockObject_MockObject */
 	private $l10n;
 
+	/** @var IClientService|\PHPUnit_Framework_MockObject_MockObject */
+	private $clientService;
+
 	public function setUp() {
 		parent::setUp();
 
 		$this->l10n = $this->createMock(IL10N::class);
 		$this->config = $this->createMock(PasswordPolicyConfig::class);
+		$this->clientService = $this->createMock(IClientService::class);
 	}
 
 	/**
@@ -49,8 +54,8 @@ class PasswordValidatorTest extends TestCase {
 	 * @return PasswordValidator | \PHPUnit_Framework_MockObject_MockObject
 	 */
 	private function getInstance($mockedMethods = []) {
-		$passwordValidator = $this->getMockBuilder('OCA\Password_Policy\PasswordValidator')
-			->setConstructorArgs([$this->config, $this->l10n])
+		$passwordValidator = $this->getMockBuilder(PasswordValidator::class)
+			->setConstructorArgs([$this->config, $this->l10n, $this->clientService])
 			->setMethods($mockedMethods)->getMock();
 
 		return $passwordValidator;


### PR DESCRIPTION
fixes #58

Allow to check against the password list of haveibeenpwned.com

Used the range method (obviously) as described in: https://haveibeenpwned.com/API/v2#SearchingPwnedPasswordsByRange

Before anyone asks shipping the file is very non practical see the size of https://haveibeenpwned.com/Passwords ;)

Todo:
- [ ] Add some more text explaining what this option means (and that is queries an external server).
- [ ] Tests?