### PR TITLE
OCS API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,17 @@ php:
   - 7.2
   - 7.3
 
+# Server requires PostgreSQL >= 9.5
+addons:
+  postgresql: "9.5"
+
 env:
   global:
     - CORE_BRANCH=master
     - APP_NAME=password_policy
   matrix:
     - DB=sqlite
-    
+
 branches:
   only:
     - master

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2019, Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+return [
+	'ocs' => [
+		[
+			'name' => 'API#generate',
+			'url'  =>'/api/v1/generate',
+			'verb' => 'GET',
+		],
+		[
+			'name' => 'API#validate',
+			'url'  =>'/api/v1/validate',
+			'verb' => 'POST',
+		]
+	]
+];

--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -23,16 +23,19 @@ declare(strict_types=1);
 
 namespace OCA\Password_Policy;
 
-
 use OCP\Capabilities\ICapability;
+use OCP\IURLGenerator;
 
 class Capabilities implements ICapability {
 
 	/** @var PasswordPolicyConfig */
 	private $config;
+	/** @var IURLGenerator */
+	private $urlGenerator;
 
-	public function __construct(PasswordPolicyConfig $config) {
+	public function __construct(PasswordPolicyConfig $config, IURLGenerator $urlGenerator) {
 		$this->config = $config;
+		$this->urlGenerator = $urlGenerator;
 	}
 
 	/**
@@ -50,6 +53,10 @@ class Capabilities implements ICapability {
 					'enforceNumericCharacters' => $this->config->getEnforceNumericCharacters(),
 					'enforceSpecialCharacters' => $this->config->getEnforceSpecialCharacters(),
 					'enforceUpperLowerCase' => $this->config->getEnforceUpperLowerCase(),
+					'api' => [
+						'generate' => $this->urlGenerator->linkToOCSRouteAbsolute('password_policy.API.generate'),
+						'validate' => $this->urlGenerator->linkToOCSRouteAbsolute('password_policy.API.validate'),
+					]
 				]
 		];
 	}

--- a/lib/Controller/APIController.php
+++ b/lib/Controller/APIController.php
@@ -1,0 +1,85 @@
+<?php
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2019, Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Password_Policy\Controller;
+
+use OC\HintException;
+use OCA\Password_Policy\Generator;
+use OCA\Password_Policy\PasswordValidator;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\AppFramework\OCSController;
+use OCP\IRequest;
+
+class APIController extends OCSController {
+
+	/** @var PasswordValidator */
+	private $validator;
+	/** @var Generator */
+	private $generator;
+
+	public function __construct(string $appName, IRequest $request, PasswordValidator $validator, Generator $generator) {
+		parent::__construct($appName, $request);
+		$this->validator = $validator;
+		$this->generator = $generator;
+	}
+
+	/**
+	 * @NoAdminRequired
+	 *
+	 * @param string $password
+	 * @return DataResponse
+	 */
+	public function validate(string $password): DataResponse {
+		try {
+			$this->validator->validate($password);
+		} catch (HintException $e) {
+			return new DataResponse([
+				'passed' => false,
+				'reason' => $e->getHint(),
+			]);
+		}
+
+		return new DataResponse([
+			'passed' => true,
+		]);
+	}
+
+	/**
+	 * @NoAdminRequired
+	 *
+	 * @return DataResponse
+	 */
+	public function generate(): DataResponse {
+		try {
+			$password = $this->generator->generate();
+		} catch (HintException $e) {
+			return new DataResponse([], Http::STATUS_CONFLICT);
+		}
+
+		return new DataResponse([
+			'password' => $password,
+		]);
+	}
+}


### PR DESCRIPTION
Fixes #82 

Adds two endpoints

* `SERVER/ocs/v2.php/apps/password_policy/api/v1/generate`
* `SERVER/ocs/v2.php/apps/password_policy/api/v1/validate`

They simply do what one can expect..

For clients (so also the web) there is a capability exposed if this is available with the full URL.
