### PR TITLE
Fix NC18 deprecation

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -20,4 +20,4 @@ declare(strict_types=1);
  *
  */
 
-$app = new \OCA\Password_Policy\AppInfo\Application();
+\OC::$server->query(\OCA\Password_Policy\AppInfo\Application::class);


### PR DESCRIPTION
In nextcloud 18 with enabled debug you'll get `App class OCA\\Password_Policy\\AppInfo\\Application is not setup via query() but directly` errors. Possibly direct instantiation will be removed in next NC versions