### PR TITLE
password expiration support

### DIFF
--- a/js/settings-admin.js
+++ b/js/settings-admin.js
@@ -42,6 +42,9 @@ var passwordPolicy = {
 				case "historySize":
 					message = OC.L10N.translate('password_policy', 'History size has to be a non negative number');
 					break;
+				case "expiration":
+					message = OC.L10N.translate('password_policy', 'Expiration days have to be a non negative number');
+					break;
 			}
 			OC.msg.finishedSaving('#password-policy-settings-msg',
 				{
@@ -93,20 +96,29 @@ $(document).ready(function(){
 		OCP.AppConfig.setValue('password_policy', 'enforceHaveIBeenPwned', value);
 	});
 
-	$('#password-policy-min-length').keyup(function (e) {
-		if (e.keyCode === 13) {
-			passwordPolicy.saveNumberValue('minLength', $(this).val());
-		}
-	}).focusout(function () {
-		passwordPolicy.saveNumberValue('minLength', $(this).val());
-	});
-
-	$('#password-policy-history-size').keyup(function (e) {
-		if (e.keyCode === 13) {
-			passwordPolicy.saveNumberValue('historySize', $(this).val());
-		}
-	}).focusout(function () {
-		passwordPolicy.saveNumberValue('historySize', $(this).val());
-	});
+	// register save handler for number input fields
+	[
+		{
+			elem: '#password-policy-min-length',
+			conf: 'minLength',
+		},
+		{
+			elem: '#password-policy-history-size',
+			conf: 'historySize',
+		},
+		{
+			elem: '#password-policy-expiration',
+			conf: 'expiration',
+		},
+	].forEach(function (configField) {
+		console.log(configField);
+		$(configField.elem).keyup(function (e) {
+			if (e.keyCode === 13) {
+				passwordPolicy.saveNumberValue(configField.conf, $(this).val());
+			}
+		}).focusout(function () {
+			passwordPolicy.saveNumberValue(configField.conf, $(this).val());
+		});
+	})
 
 });

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -25,8 +25,8 @@ declare(strict_types=1);
 namespace OCA\Password_Policy\AppInfo;
 
 use OCA\Password_Policy\Capabilities;
+use OCA\Password_Policy\ComplianceService;
 use OCA\Password_Policy\Generator;
-use OCA\Password_Policy\HistoryCompliance;
 use OCA\Password_Policy\PasswordValidator;
 use OCP\AppFramework\App;
 use OCP\EventDispatcher\Event;
@@ -36,6 +36,7 @@ use OCP\Security\Events\GenerateSecurePasswordEvent;
 use OCP\Security\Events\ValidatePasswordPolicyEvent;
 use OCP\User\Events\BeforePasswordUpdatedEvent;
 use OCP\User\Events\PasswordUpdatedEvent;
+use OCP\User\Events\PostLoginEvent;
 use Symfony\Component\EventDispatcher\GenericEvent;
 
 class Application extends App {
@@ -80,9 +81,9 @@ class Application extends App {
 				if(!($event instanceof BeforePasswordUpdatedEvent)) {
 					return;
 				}
-				/** @var HistoryCompliance $historyCompliance */
-				$historyCompliance = $container->query(HistoryCompliance::class);
-				$historyCompliance->audit($event->getUser(), $event->getPassword());
+				/** @var ComplianceService $complianceUpdater */
+				$complianceUpdater = $container->query(ComplianceService::class);
+				$complianceUpdater->audit($event->getUser(), $event->getPassword());
 			}
 		);
 		$eventDispatcher->addListener(
@@ -91,9 +92,20 @@ class Application extends App {
 				if(!($event instanceof PasswordUpdatedEvent)) {
 					return;
 				}
-				/** @var HistoryCompliance $historyCompliance */
-				$historyCompliance = $container->query(HistoryCompliance::class);
-				$historyCompliance->update($event->getUser(), $event->getPassword());
+				/** @var ComplianceService $complianceUpdater */
+				$complianceUpdater = $container->query(ComplianceService::class);
+				$complianceUpdater->update($event->getUser(), $event->getPassword());
+			}
+		);
+		$eventDispatcher->addListener(
+			PostLoginEvent::class,
+			function (Event $event) use ($container) {
+				if(!$event instanceof PostLoginEvent) {
+					return;
+				}
+				/** @var ComplianceService $complianceUpdater */
+				$complianceUpdater = $container->query(ComplianceService::class);
+				$complianceUpdater->entryControl($event->getUser(), $event->getPassword(), $event->isTokenLogin());
 			}
 		);
 

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -35,8 +35,8 @@ use OCP\ILogger;
 use OCP\Security\Events\GenerateSecurePasswordEvent;
 use OCP\Security\Events\ValidatePasswordPolicyEvent;
 use OCP\User\Events\BeforePasswordUpdatedEvent;
+use OCP\User\Events\BeforeUserLoggedInEvent;
 use OCP\User\Events\PasswordUpdatedEvent;
-use OCP\User\Events\PostLoginEvent;
 use Symfony\Component\EventDispatcher\GenericEvent;
 
 class Application extends App {
@@ -98,14 +98,14 @@ class Application extends App {
 			}
 		);
 		$eventDispatcher->addListener(
-			PostLoginEvent::class,
+			BeforeUserLoggedInEvent::class,
 			function (Event $event) use ($container) {
-				if(!$event instanceof PostLoginEvent) {
+				if(!$event instanceof BeforeUserLoggedInEvent) {
 					return;
 				}
 				/** @var ComplianceService $complianceUpdater */
 				$complianceUpdater = $container->query(ComplianceService::class);
-				$complianceUpdater->entryControl($event->getUser(), $event->getPassword(), $event->isTokenLogin());
+				$complianceUpdater->entryControl($event->getUsername(), $event->getPassword());
 			}
 		);
 

--- a/lib/Compliance/Expiration.php
+++ b/lib/Compliance/Expiration.php
@@ -64,6 +64,9 @@ class Expiration implements IUpdatable, IEntryControl {
 	 * @throws PreConditionNotMetException
 	 */
 	public function update(IUser $user, string $password): void {
+		if(!$this->isLocalUser($user)) {
+			return;
+		}
 		if($this->policyConfig->getExpiryInDays() === 0) {
 			$this->config->deleteUserValue(
 				$user->getUID(),
@@ -82,6 +85,7 @@ class Expiration implements IUpdatable, IEntryControl {
 
 	public function entryControl(IUser $user, string $password): void {
 		if($this->policyConfig->getExpiryInDays() !== 0
+			&& $this->isLocalUser($user)
 			&& $this->isPasswordExpired($user)
 		) {
 			$message = 'Password is expired, please use forgot password method to reset';
@@ -107,6 +111,11 @@ class Expiration implements IUpdatable, IEntryControl {
 		$expiresIn = $updatedAt + $expiryInDays * 24 * 60 * 60;
 
 		return $expiresIn <= time();
+	}
+
+	protected function isLocalUser(IUser $user) {
+		$localBackends = ['Database', 'Guests'];
+		return in_array($user->getBackendClassName(), $localBackends);
 	}
 
 }

--- a/lib/Compliance/Expiration.php
+++ b/lib/Compliance/Expiration.php
@@ -1,0 +1,113 @@
+<?php
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2020 Arthur Schiwon <blizzz@arthur-schiwon.de>
+ *
+ * @author Arthur Schiwon <blizzz@arthur-schiwon.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Password_Policy\Compliance;
+
+use OC\HintException;
+use OCA\Password_Policy\PasswordPolicyConfig;
+use OCP\EventDispatcher\IEventDispatcher;
+use OCP\IConfig;
+use OCP\IL10N;
+use OCP\IUser;
+use OCP\IUserManager;
+use OCP\PreConditionNotMetException;
+
+class Expiration implements IUpdatable, IEntryControl {
+
+	/** @var IConfig */
+	private $config;
+	/** @var PasswordPolicyConfig */
+	private $policyConfig;
+	/** @var IUserManager */
+	private $userManager;
+	/** @var IEventDispatcher */
+	private $eventDispatcher;
+	/** @var IL10N */
+	private $l;
+
+	public function __construct(
+		IConfig $config,
+		PasswordPolicyConfig $policyConfig,
+		IUserManager $userManager,
+		IEventDispatcher $eventDispatcher,
+		IL10N $l
+	) {
+		$this->config = $config;
+		$this->policyConfig = $policyConfig;
+		$this->userManager = $userManager;
+		$this->eventDispatcher = $eventDispatcher;
+		$this->l = $l;
+	}
+
+	/**
+	 * @throws PreConditionNotMetException
+	 */
+	public function update(IUser $user, string $password): void {
+		if($this->policyConfig->getExpiryInDays() === 0) {
+			$this->config->deleteUserValue(
+				$user->getUID(),
+				'password_policy',
+				'pwd_last_updated'
+			);
+			return;
+		}
+		$this->config->setUserValue(
+			$user->getUID(),
+			'password_policy',
+			'pwd_last_updated',
+			time()
+		);
+	}
+
+	public function entryControl(IUser $user, string $password, bool $isTokenLogin): void {
+		if($this->policyConfig->getExpiryInDays() !== 0
+			&& !$isTokenLogin
+			&& $this->isPasswordExpired($user)
+		) {
+			$message = 'Password is expired, please use forgot password method to reset';
+			$message_t = $this->l->t('Password is expired, please use forgot password method to reset');
+			throw new HintException($message, $message_t);
+		}
+	}
+
+	protected function isPasswordExpired(IUser $user) {
+		$updatedAt = (int)$this->config->getUserValue(
+			$user->getUID(),
+			'password_policy',
+			'pwd_last_updated',
+			0
+		);
+
+		if($updatedAt === 0) {
+			$this->update($user, '');
+			return false;
+		}
+
+		$expiryInDays = $this->policyConfig->getExpiryInDays();
+		$expiresIn = $updatedAt + $expiryInDays * 24 * 60 * 60;
+
+		return $expiresIn <= time();
+	}
+
+}

--- a/lib/Compliance/Expiration.php
+++ b/lib/Compliance/Expiration.php
@@ -80,9 +80,8 @@ class Expiration implements IUpdatable, IEntryControl {
 		);
 	}
 
-	public function entryControl(IUser $user, string $password, bool $isTokenLogin): void {
+	public function entryControl(IUser $user, string $password): void {
 		if($this->policyConfig->getExpiryInDays() !== 0
-			&& !$isTokenLogin
 			&& $this->isPasswordExpired($user)
 		) {
 			$message = 'Password is expired, please use forgot password method to reset';

--- a/lib/Compliance/HistoryCompliance.php
+++ b/lib/Compliance/HistoryCompliance.php
@@ -22,9 +22,10 @@ declare(strict_types=1);
  *
  */
 
-namespace OCA\Password_Policy;
+namespace OCA\Password_Policy\Compliance;
 
 use OC\HintException;
+use OCA\Password_Policy\PasswordPolicyConfig;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\ILogger;
@@ -33,7 +34,7 @@ use OCP\IUserSession;
 use OCP\PreConditionNotMetException;
 use OCP\Security\IHasher;
 
-class HistoryCompliance {
+class HistoryCompliance implements IAuditor, IUpdatable {
 	/** @var string */
 	protected $uid;
 

--- a/lib/Compliance/IAuditor.php
+++ b/lib/Compliance/IAuditor.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2020 Arthur Schiwon <blizzz@arthur-schiwon.de>
+ *
+ * @author Arthur Schiwon <blizzz@arthur-schiwon.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Password_Policy\Compliance;
+
+use OCP\IUser;
+
+interface IAuditor {
+	public function audit(IUser $user, string $password): void;
+}

--- a/lib/Compliance/IEntryControl.php
+++ b/lib/Compliance/IEntryControl.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2020 Arthur Schiwon <blizzz@arthur-schiwon.de>
+ *
+ * @author Arthur Schiwon <blizzz@arthur-schiwon.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Password_Policy\Compliance;
+
+
+use OC\HintException;
+use OCP\IUser;
+
+interface IEntryControl {
+	/**
+	 * @throws HintException
+	 */
+	public function entryControl(IUser $user, string $password, bool $isTokenLogin): void;
+}

--- a/lib/Compliance/IEntryControl.php
+++ b/lib/Compliance/IEntryControl.php
@@ -32,5 +32,5 @@ interface IEntryControl {
 	/**
 	 * @throws HintException
 	 */
-	public function entryControl(IUser $user, string $password, bool $isTokenLogin): void;
+	public function entryControl(IUser $user, string $password): void;
 }

--- a/lib/Compliance/IUpdatable.php
+++ b/lib/Compliance/IUpdatable.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2020 Arthur Schiwon <blizzz@arthur-schiwon.de>
+ *
+ * @author Arthur Schiwon <blizzz@arthur-schiwon.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Password_Policy\Compliance;
+
+use OCP\IUser;
+
+interface IUpdatable {
+	public function update(IUser $user, string $password): void;
+}

--- a/lib/ComplianceService.php
+++ b/lib/ComplianceService.php
@@ -85,14 +85,15 @@ class ComplianceService {
 	/**
 	 * @throws LoginException
 	 */
-	public function entryControl(IUser $user, string $password, bool $isTokenLogin) {
+	//public function entryControl(IUser $user, string $password, bool $isTokenLogin) {
+	public function entryControl(string $loginName, string $password) {
+		$uid = $loginName;
+		\OCP\Util::emitHook( '\OCA\Files_Sharing\API\Server2Server', 'preLoginNameUsedAsUserName', ['uid' => &$uid]);
 		foreach ($this->getInstance(IEntryControl::class) as $instance) {
 			try {
-				$instance->entryControl($user, $password, $isTokenLogin);
+				$user = \OC::$server->getUserManager()->get($uid);
+				$instance->entryControl($user, $password);
 			} catch (HintException $e) {
-				if($this->userSession->isLoggedIn()) {
-					$this->userSession->logout();
-				}
 				throw new LoginException($e->getHint());
 			}
 		}

--- a/lib/ComplianceService.php
+++ b/lib/ComplianceService.php
@@ -1,0 +1,120 @@
+<?php
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2020 Arthur Schiwon <blizzz@arthur-schiwon.de>
+ *
+ * @author Arthur Schiwon <blizzz@arthur-schiwon.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Password_Policy;
+
+use OC\HintException;
+use OC\User\LoginException;
+use OCA\Password_Policy\Compliance\Expiration;
+use OCA\Password_Policy\Compliance\HistoryCompliance;
+use OCA\Password_Policy\Compliance\IAuditor;
+use OCA\Password_Policy\Compliance\IEntryControl;
+use OCA\Password_Policy\Compliance\IUpdatable;
+use OCP\AppFramework\IAppContainer;
+use OCP\AppFramework\QueryException;
+use OCP\IConfig;
+use OCP\ILogger;
+use OCP\ISession;
+use OCP\IUser;
+use OCP\IUserSession;
+
+class ComplianceService {
+	/** @var IAppContainer */
+	protected $container;
+	/** @var ILogger */
+	protected $logger;
+
+	protected const COMPLIANCERS = [
+		HistoryCompliance::class,
+		Expiration::class,
+	];
+	/** @var IUserSession */
+	private $userSession;
+	/** @var IConfig */
+	private $config;
+	/** @var ISession */
+	private $session;
+
+	public function __construct(
+		IAppContainer $container,
+		ILogger $logger,
+		IUserSession $userSession,
+		IConfig $config,
+		ISession $session
+	) {
+		$this->container = $container;
+		$this->logger = $logger;
+		$this->userSession = $userSession;
+		$this->config = $config;
+		$this->session = $session;
+	}
+
+	public function update(IUser $user, string $password) {
+		foreach ($this->getInstance(IUpdatable::class) as $instance) {
+			$instance->update($user, $password);
+		}
+	}
+
+	public function audit(IUser $user, string $password) {
+		foreach ($this->getInstance(IAuditor::class) as $instance) {
+			$instance->audit($user, $password);
+		}
+	}
+
+	/**
+	 * @throws LoginException
+	 */
+	public function entryControl(IUser $user, string $password, bool $isTokenLogin) {
+		foreach ($this->getInstance(IEntryControl::class) as $instance) {
+			try {
+				$instance->entryControl($user, $password, $isTokenLogin);
+			} catch (HintException $e) {
+				if($this->userSession->isLoggedIn()) {
+					$this->userSession->logout();
+				}
+				throw new LoginException($e->getHint());
+			}
+		}
+	}
+
+	/**
+	 * @returns Iterable
+	 */
+	protected function getInstance($interface) {
+		foreach (self::COMPLIANCERS as $compliance) {
+			try {
+				$instance = $this->container->query($compliance);
+				if(!$instance instanceof $interface) {
+					continue;
+				}
+			} catch (QueryException $e) {
+				//ignore and continue
+				$this->logger->logException($e, ['level' => ILogger::INFO]);
+				continue;
+			}
+
+			yield $instance;
+		}
+	}
+}

--- a/lib/PasswordPolicyConfig.php
+++ b/lib/PasswordPolicyConfig.php
@@ -185,4 +185,12 @@ class PasswordPolicyConfig {
 		);
 	}
 
+	public function getExpiryInDays(): int {
+		return (int)$this->config->getAppValue(
+			'password_policy',
+			'expiration',
+			0
+		);
+	}
+
 }

--- a/lib/Settings.php
+++ b/lib/Settings.php
@@ -46,6 +46,7 @@ class Settings implements ISettings {
 			'enforceSpecialCharacters' => $this->config->getEnforceSpecialCharacters(),
 			'enforceHaveIBeenPwned' => $this->config->getEnforceHaveIBeenPwned(),
 			'historySize' => $this->config->getHistorySize(),
+			'expiration' => $this->config->getExpiryInDays(),
 		]);
 
 		return $response;

--- a/templates/settings-admin.php
+++ b/templates/settings-admin.php
@@ -41,6 +41,12 @@ style('password_policy', 'settings-admin');
 			<span><?php p($l->t('User password history')) ?></span>
 		</label>
 	</p>
+	<p>
+		<label class="password-policy-number-option">
+			<input id="password-policy-expiration" type="number" value="<?php p($_['expiration']) ?>" />
+			<span><?php p($l->t('days until user password expires')) ?></span>
+		</label>
+	</p>
 	<p id="enforceNonCommonPassword">
 		<input type="checkbox" name="password-policy-enforce-non-common-password" id="password-policy-enforce-non-common-password" class="checkbox"
 			   value="1" <?php if ($_['enforceNonCommonPassword']) print_unescaped('checked="checked"'); ?> />

--- a/tests/lib/Compliance/HistoryComplianceTest.php
+++ b/tests/lib/Compliance/HistoryComplianceTest.php
@@ -22,10 +22,10 @@ declare(strict_types=1);
  *
  */
 
-namespace OCA\Password_Policy\Tests;
+namespace OCA\Password_Policy\Tests\Compliance;
 
 use OC\HintException;
-use OCA\Password_Policy\HistoryCompliance;
+use OCA\Password_Policy\Compliance\HistoryCompliance;
 use OCA\Password_Policy\PasswordPolicyConfig;
 use OCP\IConfig;
 use OCP\IL10N;


### PR DESCRIPTION
My straight forward attempt is here to check the password validity after the login succeeded against the backend. Only in that case we certainly know, who the users is (not just the loginname) and can be certain that the password used to be right. This avoids that information is leaked to the outside (user enumeration? chance for social engineering?), although it comes at costs, that already postLogin events were done by other apps (for instance, the lastLogin timestamp is already set). 

We could act in the BeforeUserLoggedInEvent event, with the constraints named above, and need guessing over the user id (we have mechanisms). I tend to change it thereto. 

* [x] last login might be updated despite rejected login
* [ ] error page is unfriendly (best message with login mask) (server issue)
* [ ] notification couple days advance (perhaps separate PR?)
* [x] take out users from foreign backends
* [ ] extends tests