### PR TITLE
fix: null password handling in entry control logic

### DIFF
--- a/lib/Compliance/Expiration.php
+++ b/lib/Compliance/Expiration.php
@@ -84,7 +84,7 @@ class Expiration implements IUpdatable, IEntryControl {
 		);
 	}
 
-	public function entryControl(IUser $user, string $password): void {
+	public function entryControl(IUser $user, ?string $password): void {
 		if ($this->policyConfig->getExpiryInDays() !== 0
 			&& $this->isLocalUser($user)
 			&& $this->isPasswordExpired($user)

--- a/lib/Compliance/IEntryControl.php
+++ b/lib/Compliance/IEntryControl.php
@@ -32,5 +32,5 @@ interface IEntryControl {
 	/**
 	 * @throws HintException
 	 */
-	public function entryControl(IUser $user, string $password): void;
+	public function entryControl(IUser $user, ?string $password): void;
 }

--- a/lib/ComplianceService.php
+++ b/lib/ComplianceService.php
@@ -87,9 +87,11 @@ class ComplianceService {
 	 * @throws LoginException
 	 */
 	//public function entryControl(IUser $user, string $password, bool $isTokenLogin) {
-	public function entryControl(string $loginName, string $password) {
+	public function entryControl(string $loginName, ?string $password) {
 		$uid = $loginName;
 		\OCP\Util::emitHook('\OCA\Files_Sharing\API\Server2Server', 'preLoginNameUsedAsUserName', ['uid' => &$uid]);
+
+		/** @var IEntryControl $instance */
 		foreach ($this->getInstance(IEntryControl::class) as $instance) {
 			try {
 				$user = \OC::$server->getUserManager()->get($uid);


### PR DESCRIPTION
Fix #448
Fix https://github.com/nextcloud/user_saml/issues/709

`BeforeUserLoggedInEvent` is allowed to contain no password (`string|null`). However, the entry control logic fails if the password is null, because it always expects a string.

```php
public function entryControl(string $loginName, string $password) {}
```

I fixed this by also allowing null for the password. There is only one implementation of the `IEntryControl` interface in this app and it doesn't even make use of the password param so this should be safe change.

There don't seem to be any other implementations of this interface outside this app (source: GitHub search for `IEntryControl`).