### PR TITLE
fix: Move from private `OC\HintException` to public `OCP\HintException`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,12 @@
 	"require-dev": {
 		"christophwurst/nextcloud_testing": "^1.0.0",
 		"nextcloud/coding-standard": "^1.0.0",
+		"nextcloud/ocp": "dev-master",
 		"phpunit/phpunit": "^9.5"
+	},
+	"autoload-dev": {
+		"psr-4": {
+			"OCP\\": "vendor/nextcloud/ocp/OCP"
+		}
 	}
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1a0c573f3106a3aacc4e768dc4bf64ee",
+    "content-hash": "d7e62d3f614ff4d8a55bbe509aee8288",
     "packages": [],
     "packages-dev": [
         {
@@ -121,16 +121,16 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.11.1",
+            "version": "1.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "7284c22080590fb39f2ffa3e9057f10a4ddd0e0c"
+                "reference": "3a6b9a42cd8f8771bd4295d13e1423fa7f3d942c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/7284c22080590fb39f2ffa3e9057f10a4ddd0e0c",
-                "reference": "7284c22080590fb39f2ffa3e9057f10a4ddd0e0c",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3a6b9a42cd8f8771bd4295d13e1423fa7f3d942c",
+                "reference": "3a6b9a42cd8f8771bd4295d13e1423fa7f3d942c",
                 "shasum": ""
             },
             "require": {
@@ -138,11 +138,12 @@
             },
             "conflict": {
                 "doctrine/collections": "<1.6.8",
-                "doctrine/common": "<2.13.3 || >=3,<3.2.2"
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
             },
             "require-dev": {
                 "doctrine/collections": "^1.6.8",
                 "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
                 "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
             },
             "type": "library",
@@ -168,7 +169,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.11.1"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.12.0"
             },
             "funding": [
                 {
@@ -176,7 +177,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-08T13:26:56+00:00"
+            "time": "2024-06-12T14:39:25+00:00"
         },
         {
             "name": "nextcloud/coding-standard",
@@ -220,17 +221,62 @@
             "time": "2024-02-01T14:54:37+00:00"
         },
         {
-            "name": "nikic/php-parser",
-            "version": "v5.0.2",
+            "name": "nextcloud/ocp",
+            "version": "dev-master",
             "source": {
                 "type": "git",
-                "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "139676794dc1e9231bf7bcd123cfc0c99182cb13"
+                "url": "https://github.com/nextcloud-deps/ocp.git",
+                "reference": "b0127d6fd2932bf1fdffe334ae59fdd6c8272029"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/139676794dc1e9231bf7bcd123cfc0c99182cb13",
-                "reference": "139676794dc1e9231bf7bcd123cfc0c99182cb13",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/b0127d6fd2932bf1fdffe334ae59fdd6c8272029",
+                "reference": "b0127d6fd2932bf1fdffe334ae59fdd6c8272029",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~8.0 || ~8.1 || ~8.2 || ~8.3",
+                "psr/clock": "^1.0",
+                "psr/container": "^2.0.2",
+                "psr/event-dispatcher": "^1.0",
+                "psr/log": "^1.1.4"
+            },
+            "default-branch": true,
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "31.0.0-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "AGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Christoph Wurst",
+                    "email": "christoph@winzerhof-wurst.at"
+                }
+            ],
+            "description": "Composer package containing Nextcloud's public API (classes, interfaces)",
+            "support": {
+                "issues": "https://github.com/nextcloud-deps/ocp/issues",
+                "source": "https://github.com/nextcloud-deps/ocp/tree/master"
+            },
+            "time": "2024-08-14T08:51:54+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v5.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "683130c2ff8c2739f4822ff7ac5c873ec529abd1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/683130c2ff8c2739f4822ff7ac5c873ec529abd1",
+                "reference": "683130c2ff8c2739f4822ff7ac5c873ec529abd1",
                 "shasum": ""
             },
             "require": {
@@ -241,7 +287,7 @@
             },
             "require-dev": {
                 "ircmaxell/php-yacc": "^0.0.7",
-                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
+                "phpunit/phpunit": "^9.0"
             },
             "bin": [
                 "bin/php-parse"
@@ -273,9 +319,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.0.2"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.1.0"
             },
-            "time": "2024-03-05T20:51:40+00:00"
+            "time": "2024-07-01T20:03:41+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -397,16 +443,16 @@
         },
         {
             "name": "php-cs-fixer/shim",
-            "version": "v3.54.0",
+            "version": "v3.62.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/shim.git",
-                "reference": "887c350fccbadb2b84278fdb963c25a0c304ac9c"
+                "reference": "7a91d5ce45c486f5b445d95901228507a02f60ae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/shim/zipball/887c350fccbadb2b84278fdb963c25a0c304ac9c",
-                "reference": "887c350fccbadb2b84278fdb963c25a0c304ac9c",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/shim/zipball/7a91d5ce45c486f5b445d95901228507a02f60ae",
+                "reference": "7a91d5ce45c486f5b445d95901228507a02f60ae",
                 "shasum": ""
             },
             "require": {
@@ -443,9 +489,9 @@
             "description": "A tool to automatically fix PHP code style",
             "support": {
                 "issues": "https://github.com/PHP-CS-Fixer/shim/issues",
-                "source": "https://github.com/PHP-CS-Fixer/shim/tree/v3.54.0"
+                "source": "https://github.com/PHP-CS-Fixer/shim/tree/v3.62.0"
             },
-            "time": "2024-04-17T08:23:10+00:00"
+            "time": "2024-08-07T17:03:46+00:00"
         },
         {
             "name": "php-webdriver/webdriver",
@@ -834,45 +880,45 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.19",
+            "version": "9.6.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "a1a54a473501ef4cdeaae4e06891674114d79db8"
+                "reference": "49d7820565836236411f5dc002d16dd689cde42f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a1a54a473501ef4cdeaae4e06891674114d79db8",
-                "reference": "a1a54a473501ef4cdeaae4e06891674114d79db8",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/49d7820565836236411f5dc002d16dd689cde42f",
+                "reference": "49d7820565836236411f5dc002d16dd689cde42f",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.3.1 || ^2",
+                "doctrine/instantiator": "^1.5.0 || ^2",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xml": "*",
                 "ext-xmlwriter": "*",
-                "myclabs/deep-copy": "^1.10.1",
-                "phar-io/manifest": "^2.0.3",
-                "phar-io/version": "^3.0.2",
+                "myclabs/deep-copy": "^1.12.0",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
                 "php": ">=7.3",
-                "phpunit/php-code-coverage": "^9.2.28",
-                "phpunit/php-file-iterator": "^3.0.5",
+                "phpunit/php-code-coverage": "^9.2.31",
+                "phpunit/php-file-iterator": "^3.0.6",
                 "phpunit/php-invoker": "^3.1.1",
-                "phpunit/php-text-template": "^2.0.3",
-                "phpunit/php-timer": "^5.0.2",
-                "sebastian/cli-parser": "^1.0.1",
-                "sebastian/code-unit": "^1.0.6",
+                "phpunit/php-text-template": "^2.0.4",
+                "phpunit/php-timer": "^5.0.3",
+                "sebastian/cli-parser": "^1.0.2",
+                "sebastian/code-unit": "^1.0.8",
                 "sebastian/comparator": "^4.0.8",
-                "sebastian/diff": "^4.0.3",
-                "sebastian/environment": "^5.1.3",
-                "sebastian/exporter": "^4.0.5",
-                "sebastian/global-state": "^5.0.1",
-                "sebastian/object-enumerator": "^4.0.3",
-                "sebastian/resource-operations": "^3.0.3",
-                "sebastian/type": "^3.2",
+                "sebastian/diff": "^4.0.6",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/exporter": "^4.0.6",
+                "sebastian/global-state": "^5.0.7",
+                "sebastian/object-enumerator": "^4.0.4",
+                "sebastian/resource-operations": "^3.0.4",
+                "sebastian/type": "^3.2.1",
                 "sebastian/version": "^3.0.2"
             },
             "suggest": {
@@ -917,7 +963,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.19"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.20"
             },
             "funding": [
                 {
@@ -933,7 +979,208 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-05T04:35:58+00:00"
+            "time": "2024-07-10T11:45:39+00:00"
+        },
+        {
+            "name": "psr/clock",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/clock.git",
+                "reference": "e41a24703d4560fd0acb709162f73b8adfc3aa0d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/clock/zipball/e41a24703d4560fd0acb709162f73b8adfc3aa0d",
+                "reference": "e41a24703d4560fd0acb709162f73b8adfc3aa0d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Clock\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for reading the clock.",
+            "homepage": "https://github.com/php-fig/clock",
+            "keywords": [
+                "clock",
+                "now",
+                "psr",
+                "psr-20",
+                "time"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/clock/issues",
+                "source": "https://github.com/php-fig/clock/tree/1.0.0"
+            },
+            "time": "2022-11-25T14:36:26+00:00"
+        },
+        {
+            "name": "psr/container",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/container/issues",
+                "source": "https://github.com/php-fig/container/tree/2.0.2"
+            },
+            "time": "2021-11-05T16:47:00+00:00"
+        },
+        {
+            "name": "psr/event-dispatcher",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/event-dispatcher.git",
+                "reference": "dbefd12671e8a14ec7f180cab83036ed26714bb0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/event-dispatcher/zipball/dbefd12671e8a14ec7f180cab83036ed26714bb0",
+                "reference": "dbefd12671e8a14ec7f180cab83036ed26714bb0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\EventDispatcher\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Standard interfaces for event handling.",
+            "keywords": [
+                "events",
+                "psr",
+                "psr-14"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/event-dispatcher/issues",
+                "source": "https://github.com/php-fig/event-dispatcher/tree/1.0.0"
+            },
+            "time": "2019-01-08T18:20:26+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "1.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "d49695b909c3b7628b6289db5479a1c204601f11"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/d49695b909c3b7628b6289db5479a1c204601f11",
+                "reference": "d49695b909c3b7628b6289db5479a1c204601f11",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "Psr/Log/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/1.1.4"
+            },
+            "time": "2021-05-03T11:20:27+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -1900,16 +2147,16 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.29.0",
+            "version": "v1.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "9773676c8a1bb1f8d4340a62efe641cf76eda7ec"
+                "reference": "fd22ab50000ef01661e2a31d850ebaa297f8e03c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/9773676c8a1bb1f8d4340a62efe641cf76eda7ec",
-                "reference": "9773676c8a1bb1f8d4340a62efe641cf76eda7ec",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/fd22ab50000ef01661e2a31d850ebaa297f8e03c",
+                "reference": "fd22ab50000ef01661e2a31d850ebaa297f8e03c",
                 "shasum": ""
             },
             "require": {
@@ -1960,7 +2207,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.29.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.30.0"
             },
             "funding": [
                 {
@@ -1976,20 +2223,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-29T20:11:03+00:00"
+            "time": "2024-06-19T12:30:46+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.29.0",
+            "version": "v1.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "87b68208d5c1188808dd7839ee1e6c8ec3b02f1b"
+                "reference": "77fa7995ac1b21ab60769b7323d600a991a90433"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/87b68208d5c1188808dd7839ee1e6c8ec3b02f1b",
-                "reference": "87b68208d5c1188808dd7839ee1e6c8ec3b02f1b",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/77fa7995ac1b21ab60769b7323d600a991a90433",
+                "reference": "77fa7995ac1b21ab60769b7323d600a991a90433",
                 "shasum": ""
             },
             "require": {
@@ -2040,7 +2287,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.29.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.30.0"
             },
             "funding": [
                 {
@@ -2056,20 +2303,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-29T20:11:03+00:00"
+            "time": "2024-05-31T15:07:36+00:00"
         },
         {
             "name": "symfony/process",
-            "version": "v5.4.36",
+            "version": "v5.4.40",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "4fdf34004f149cc20b2f51d7d119aa500caad975"
+                "reference": "deedcb3bb4669cae2148bc920eafd2b16dc7c046"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/4fdf34004f149cc20b2f51d7d119aa500caad975",
-                "reference": "4fdf34004f149cc20b2f51d7d119aa500caad975",
+                "url": "https://api.github.com/repos/symfony/process/zipball/deedcb3bb4669cae2148bc920eafd2b16dc7c046",
+                "reference": "deedcb3bb4669cae2148bc920eafd2b16dc7c046",
                 "shasum": ""
             },
             "require": {
@@ -2102,7 +2349,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v5.4.36"
+                "source": "https://github.com/symfony/process/tree/v5.4.40"
             },
             "funding": [
                 {
@@ -2118,7 +2365,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-02-12T15:49:53+00:00"
+            "time": "2024-05-31T14:33:22+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -2173,7 +2420,9 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "nextcloud/ocp": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],

--- a/lib/Compliance/Expiration.php
+++ b/lib/Compliance/Expiration.php
@@ -8,9 +8,9 @@ declare(strict_types=1);
 
 namespace OCA\Password_Policy\Compliance;
 
-use OC\HintException;
 use OCA\Password_Policy\PasswordPolicyConfig;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\HintException;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IUser;

--- a/lib/Compliance/HistoryCompliance.php
+++ b/lib/Compliance/HistoryCompliance.php
@@ -8,8 +8,8 @@ declare(strict_types=1);
 
 namespace OCA\Password_Policy\Compliance;
 
-use OC\HintException;
 use OCA\Password_Policy\PasswordPolicyConfig;
+use OCP\HintException;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IUser;

--- a/lib/Compliance/IEntryControl.php
+++ b/lib/Compliance/IEntryControl.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 
 namespace OCA\Password_Policy\Compliance;
 
-use OC\HintException;
+use OCP\HintException;
 use OCP\IUser;
 
 interface IEntryControl {

--- a/lib/ComplianceService.php
+++ b/lib/ComplianceService.php
@@ -8,13 +8,13 @@ declare(strict_types=1);
 
 namespace OCA\Password_Policy;
 
-use OC\HintException;
 use OC\User\LoginException;
 use OCA\Password_Policy\Compliance\Expiration;
 use OCA\Password_Policy\Compliance\HistoryCompliance;
 use OCA\Password_Policy\Compliance\IAuditor;
 use OCA\Password_Policy\Compliance\IEntryControl;
 use OCA\Password_Policy\Compliance\IUpdatable;
+use OCP\HintException;
 use OCP\IConfig;
 use OCP\ISession;
 use OCP\IUser;

--- a/lib/Controller/APIController.php
+++ b/lib/Controller/APIController.php
@@ -8,12 +8,12 @@ declare(strict_types=1);
 
 namespace OCA\Password_Policy\Controller;
 
-use OC\HintException;
 use OCA\Password_Policy\Generator;
 use OCA\Password_Policy\PasswordValidator;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\OCSController;
+use OCP\HintException;
 use OCP\IRequest;
 
 class APIController extends OCSController {

--- a/lib/Generator.php
+++ b/lib/Generator.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 
 namespace OCA\Password_Policy;
 
-use OC\HintException;
+use OCP\HintException;
 use OCP\Security\ISecureRandom;
 
 class Generator {

--- a/lib/PasswordValidator.php
+++ b/lib/PasswordValidator.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace OCA\Password_Policy;
 
-use OC\HintException;
 use OCA\Password_Policy\Validator\CommonPasswordsValidator;
 use OCA\Password_Policy\Validator\HIBPValidator;
 use OCA\Password_Policy\Validator\IValidator;
@@ -17,6 +16,7 @@ use OCA\Password_Policy\Validator\LengthValidator;
 use OCA\Password_Policy\Validator\NumericCharacterValidator;
 use OCA\Password_Policy\Validator\SpecialCharactersValidator;
 use OCA\Password_Policy\Validator\UpperCaseLoweCaseValidator;
+use OCP\HintException;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;

--- a/lib/Validator/CommonPasswordsValidator.php
+++ b/lib/Validator/CommonPasswordsValidator.php
@@ -8,8 +8,8 @@ declare(strict_types=1);
 
 namespace OCA\Password_Policy\Validator;
 
-use OC\HintException;
 use OCA\Password_Policy\PasswordPolicyConfig;
+use OCP\HintException;
 use OCP\IL10N;
 
 class CommonPasswordsValidator implements IValidator {

--- a/lib/Validator/HIBPValidator.php
+++ b/lib/Validator/HIBPValidator.php
@@ -8,8 +8,8 @@ declare(strict_types=1);
 
 namespace OCA\Password_Policy\Validator;
 
-use OC\HintException;
 use OCA\Password_Policy\PasswordPolicyConfig;
+use OCP\HintException;
 use OCP\Http\Client\IClientService;
 use OCP\IL10N;
 use Psr\Log\LoggerInterface;

--- a/lib/Validator/IValidator.php
+++ b/lib/Validator/IValidator.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 
 namespace OCA\Password_Policy\Validator;
 
-use OC\HintException;
+use OCP\HintException;
 
 interface IValidator {
 

--- a/lib/Validator/LengthValidator.php
+++ b/lib/Validator/LengthValidator.php
@@ -8,8 +8,8 @@ declare(strict_types=1);
 
 namespace OCA\Password_Policy\Validator;
 
-use OC\HintException;
 use OCA\Password_Policy\PasswordPolicyConfig;
+use OCP\HintException;
 use OCP\IL10N;
 
 class LengthValidator implements IValidator {

--- a/lib/Validator/NumericCharacterValidator.php
+++ b/lib/Validator/NumericCharacterValidator.php
@@ -8,8 +8,8 @@ declare(strict_types=1);
 
 namespace OCA\Password_Policy\Validator;
 
-use OC\HintException;
 use OCA\Password_Policy\PasswordPolicyConfig;
+use OCP\HintException;
 use OCP\IL10N;
 
 class NumericCharacterValidator implements IValidator {

--- a/lib/Validator/SpecialCharactersValidator.php
+++ b/lib/Validator/SpecialCharactersValidator.php
@@ -8,8 +8,8 @@ declare(strict_types=1);
 
 namespace OCA\Password_Policy\Validator;
 
-use OC\HintException;
 use OCA\Password_Policy\PasswordPolicyConfig;
+use OCP\HintException;
 use OCP\IL10N;
 
 class SpecialCharactersValidator implements IValidator {

--- a/lib/Validator/UpperCaseLoweCaseValidator.php
+++ b/lib/Validator/UpperCaseLoweCaseValidator.php
@@ -8,8 +8,8 @@ declare(strict_types=1);
 
 namespace OCA\Password_Policy\Validator;
 
-use OC\HintException;
 use OCA\Password_Policy\PasswordPolicyConfig;
+use OCP\HintException;
 use OCP\IL10N;
 
 class UpperCaseLoweCaseValidator implements IValidator {

--- a/tests/lib/Compliance/HistoryComplianceTest.php
+++ b/tests/lib/Compliance/HistoryComplianceTest.php
@@ -9,9 +9,9 @@ declare(strict_types=1);
 namespace OCA\Password_Policy\Tests\Compliance;
 
 use ChristophWurst\Nextcloud\Testing\TestCase;
-use OC\HintException;
 use OCA\Password_Policy\Compliance\HistoryCompliance;
 use OCA\Password_Policy\PasswordPolicyConfig;
+use OCP\HintException;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IUser;

--- a/tests/lib/Validator/CommonPasswordsValidatorTest.php
+++ b/tests/lib/Validator/CommonPasswordsValidatorTest.php
@@ -9,10 +9,10 @@ declare(strict_types=1);
 namespace OCA\Password_Policy\Tests\Validator;
 
 use ChristophWurst\Nextcloud\Testing\TestCase;
-use OC\HintException;
 use OCA\Password_Policy\PasswordPolicyConfig;
 use OCA\Password_Policy\Validator\CommonPasswordsValidator;
 use OCA\Password_Policy\Validator\IValidator;
+use OCP\HintException;
 use OCP\IL10N;
 use PHPUnit\Framework\MockObject\MockObject;
 

--- a/tests/lib/Validator/LengthValidatorTest.php
+++ b/tests/lib/Validator/LengthValidatorTest.php
@@ -9,10 +9,10 @@ declare(strict_types=1);
 namespace OCA\Password_Policy\Tests\Validator;
 
 use ChristophWurst\Nextcloud\Testing\TestCase;
-use OC\HintException;
 use OCA\Password_Policy\PasswordPolicyConfig;
 use OCA\Password_Policy\Validator\IValidator;
 use OCA\Password_Policy\Validator\LengthValidator;
+use OCP\HintException;
 use OCP\IL10N;
 use PHPUnit\Framework\MockObject\MockObject;
 

--- a/tests/lib/Validator/NumericCharacterValidatorTest.php
+++ b/tests/lib/Validator/NumericCharacterValidatorTest.php
@@ -9,10 +9,10 @@ declare(strict_types=1);
 namespace OCA\Password_Policy\Tests\Validator;
 
 use ChristophWurst\Nextcloud\Testing\TestCase;
-use OC\HintException;
 use OCA\Password_Policy\PasswordPolicyConfig;
 use OCA\Password_Policy\Validator\IValidator;
 use OCA\Password_Policy\Validator\NumericCharacterValidator;
+use OCP\HintException;
 use OCP\IL10N;
 use PHPUnit\Framework\MockObject\MockObject;
 

--- a/tests/lib/Validator/SpecialCharactersValidatorTest.php
+++ b/tests/lib/Validator/SpecialCharactersValidatorTest.php
@@ -9,10 +9,10 @@ declare(strict_types=1);
 namespace OCA\Password_Policy\Tests\Validator;
 
 use ChristophWurst\Nextcloud\Testing\TestCase;
-use OC\HintException;
 use OCA\Password_Policy\PasswordPolicyConfig;
 use OCA\Password_Policy\Validator\IValidator;
 use OCA\Password_Policy\Validator\SpecialCharactersValidator;
+use OCP\HintException;
 use OCP\IL10N;
 use PHPUnit\Framework\MockObject\MockObject;
 

--- a/tests/lib/Validator/UpperCaseLowerCaseValidatorTest.php
+++ b/tests/lib/Validator/UpperCaseLowerCaseValidatorTest.php
@@ -9,10 +9,10 @@ declare(strict_types=1);
 namespace OCA\Password_Policy\Tests\Validator;
 
 use ChristophWurst\Nextcloud\Testing\TestCase;
-use OC\HintException;
 use OCA\Password_Policy\PasswordPolicyConfig;
 use OCA\Password_Policy\Validator\IValidator;
 use OCA\Password_Policy\Validator\UpperCaseLoweCaseValidator;
+use OCP\HintException;
 use OCP\IL10N;
 use PHPUnit\Framework\MockObject\MockObject;
 


### PR DESCRIPTION
We should not use private API in apps, especially if there is a public alternative.