### PR TITLE
refactor: Migrate away from deprecated `ILogger` to PSR-3

### DIFF
--- a/lib/Compliance/HistoryCompliance.php
+++ b/lib/Compliance/HistoryCompliance.php
@@ -12,43 +12,22 @@ use OC\HintException;
 use OCA\Password_Policy\PasswordPolicyConfig;
 use OCP\IConfig;
 use OCP\IL10N;
-use OCP\ILogger;
 use OCP\IUser;
 use OCP\IUserSession;
 use OCP\PreConditionNotMetException;
 use OCP\Security\IHasher;
+use Psr\Log\LoggerInterface;
 
 class HistoryCompliance implements IAuditor, IUpdatable {
-	/** @var string */
-	protected $uid;
-
-	/** @var PasswordPolicyConfig */
-	private $policyConfig;
-	/** @var IConfig */
-	private $config;
-	/** @var IUserSession */
-	private $session;
-	/** @var IHasher */
-	private $hasher;
-	/** @var IL10N */
-	private $l;
-	/** @var ILogger */
-	private $logger;
 
 	public function __construct(
-		PasswordPolicyConfig $policyConfig,
-		IConfig $config,
-		IUserSession $session,
-		IHasher $hasher,
-		IL10N $l,
-		ILogger $logger
+		protected PasswordPolicyConfig $policyConfig,
+		protected IConfig $config,
+		protected IUserSession $session,
+		protected IHasher $hasher,
+		protected IL10N $l,
+		protected LoggerInterface $logger
 	) {
-		$this->policyConfig = $policyConfig;
-		$this->config = $config;
-		$this->session = $session;
-		$this->hasher = $hasher;
-		$this->l = $l;
-		$this->logger = $logger;
 	}
 
 	/**

--- a/lib/Validator/HIBPValidator.php
+++ b/lib/Validator/HIBPValidator.php
@@ -12,27 +12,16 @@ use OC\HintException;
 use OCA\Password_Policy\PasswordPolicyConfig;
 use OCP\Http\Client\IClientService;
 use OCP\IL10N;
-use OCP\ILogger;
+use Psr\Log\LoggerInterface;
 
 class HIBPValidator implements IValidator {
 
-	/** @var PasswordPolicyConfig */
-	private $config;
-	/** @var IL10N */
-	private $l;
-	/** @var IClientService */
-	private $clientService;
-	/** @var ILogger */
-	private $logger;
-
-	public function __construct(PasswordPolicyConfig $config,
-		IL10N $l,
-		IClientService $clientService,
-		ILogger $logger) {
-		$this->config = $config;
-		$this->l = $l;
-		$this->clientService = $clientService;
-		$this->logger = $logger;
+	public function __construct(
+		private PasswordPolicyConfig $config,
+		private IL10N $l,
+		private IClientService $clientService,
+		private LoggerInterface $logger,
+	) {
 	}
 
 	public function validate(string $password): void {
@@ -54,7 +43,7 @@ class HIBPValidator implements IValidator {
 					]
 				);
 			} catch (\Exception $e) {
-				$this->logger->logException($e, ['level' => ILogger::INFO]);
+				$this->logger->info('Could not connect to HaveIBeenPwned API', ['exception' => $e]);
 				return;
 			}
 

--- a/tests/lib/Compliance/HistoryComplianceTest.php
+++ b/tests/lib/Compliance/HistoryComplianceTest.php
@@ -31,24 +31,19 @@ use OCA\Password_Policy\Compliance\HistoryCompliance;
 use OCA\Password_Policy\PasswordPolicyConfig;
 use OCP\IConfig;
 use OCP\IL10N;
-use OCP\ILogger;
 use OCP\IUser;
 use OCP\IUserSession;
 use OCP\Security\IHasher;
 use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
 
 class HistoryComplianceTest extends TestCase {
 
-	/** @var HistoryCompliance */
-	protected $instance;
-	/** @var PasswordPolicyConfig|MockObject */
-	protected $policyConfig;
-	/** @var IConfig|MockObject */
-	protected $config;
-	/** @var IUserSession|MockObject */
-	protected $session;
-	/** @var IHasher|MockObject */
-	protected $hasher;
+	protected HistoryCompliance $instance;
+	protected PasswordPolicyConfig&MockObject $policyConfig;
+	protected IConfig&MockObject $config;
+	protected IUserSession&MockObject $session;
+	protected IHasher&MockObject $hasher;
 
 	public function setUp(): void {
 		parent::setUp();
@@ -58,13 +53,18 @@ class HistoryComplianceTest extends TestCase {
 		$this->session = $this->createMock(IUserSession::class);
 		$this->hasher = $this->createMock(IHasher::class);
 
+		/** @var IL10N&MockObject */
+		$l10n = $this->createMock(IL10N::class);
+		/** @var LoggerInterface&MockObject */
+		$logger = $this->createMock(LoggerInterface::class);
+
 		$this->instance = new HistoryCompliance(
 			$this->policyConfig,
 			$this->config,
 			$this->session,
 			$this->hasher,
-			$this->createMock(IL10N::class),
-			$this->createMock(ILogger::class)
+			$l10n,
+			$logger,
 		);
 	}
 


### PR DESCRIPTION
Mostly replace `ILogger` with `LoggerInterface` and some minor cleanup (constructor property promotion).

Some places used the deprecated `logException`, this is easy to migrate: Simply use the appropriate log level on the logger and place the exception under the `exception` key in the context.