### PR TITLE
chore: Safe-guard composer-bin-plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
 	},
 	"scripts": {
 		"post-install-cmd": [
-			"@composer bin all install --ansi"
+			"[ $COMPOSER_DEV_MODE -eq 0 ] || @composer bin all install --ansi"
 		],
 		"post-update-cmd": [
 			"@composer bin all update --ansi"


### PR DESCRIPTION
Running composer install --no-dev fails with Command "bin" is not defined because the plugin is in require-dev. A script named "bin" avoids the failure.