### PR TITLE
feat(settings): implement IDelegatedSettings for password policy settings

### DIFF
--- a/lib/Settings/Settings.php
+++ b/lib/Settings/Settings.php
@@ -11,15 +11,17 @@ namespace OCA\Password_Policy\Settings;
 use OCA\Password_Policy\PasswordPolicyConfig;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Services\IInitialState;
-use OCP\Settings\ISettings;
+use OCP\IL10N;
+use OCP\Settings\IDelegatedSettings;
 use OCP\Util;
 
-class Settings implements ISettings {
+class Settings implements IDelegatedSettings {
 
 	public function __construct(
 		private string $appName,
 		private PasswordPolicyConfig $config,
 		private IInitialState $initialStateService,
+		private IL10N $l10n,
 	) {
 	}
 
@@ -45,5 +47,15 @@ class Settings implements ISettings {
 	#[\Override]
 	public function getPriority(): int {
 		return 50;
+	}
+
+	#[\Override]
+	public function getName(): string {
+		return $this->l10n->t('Password Policy');
+	}
+
+	#[\Override]
+	public function getAuthorizedAppConfig(): array {
+		return [];
 	}
 }


### PR DESCRIPTION
## Summary

Implements `IDelegatedSettings` for the password policy admin settings page (`OCA\Password_Policy\Settings\Settings`), instead of the plain `ISettings` interface. This allows an administrator to delegate management of the password policy to a non-admin user or group via the admin delegation feature, without granting full admin rights.

- `getName()` returns the translated section label, `Password Policy`.
- `getAuthorizedAppConfig()` returns `[]` — no app config keys are exposed for direct delegated editing beyond the settings form itself.
- `IL10N` is added as a promoted constructor parameter for the label; it is autowired, so no DI registration change is needed.
- `#[\Override]` is set on both new methods, matching the rest of the class.

Companion to https://github.com/nextcloud/bruteforcesettings/pull/1246, which makes the same change for the brute-force IP allowlist settings.

## AI disclosure

This change was prepared with AI assistance (Claude Code): the cherry-pick and rebase mechanics onto current `master`, the `#[\Override]` consistency fix, and this PR description. The underlying code change and the DCO sign-off are from a human contributor.

## Testing

- `composer lint` — clean
- `composer cs:check` — clean, 0 of 41 files need fixing
- `composer psalm` was not run locally: the pinned Psalm requires PHP >= 8.3.16 and the available container has PHP 8.3.6. Note that `master` already reports a `DocblockTypeContradiction` at `lib/Validator/HIBPValidator.php:54` independently of this change; it is not addressed here.
- `composer test:unit` was not run locally: the bootstrap needs an installed Nextcloud instance. No existing test touches this settings class.
